### PR TITLE
feat: load MathJax from CDN when not available

### DIFF
--- a/ts/mathjax/base.ts
+++ b/ts/mathjax/base.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
+
+export abstract class BaseMathJaxHelper {
+    protected abstract cdnUrl: string;
+    protected mathjax: any;
+
+    private renderQueue: Promise<void> = Promise.resolve();
+
+    /**
+     * MathJax helper.
+     *
+     * If the `mathjax` parameter is undefined, MathJax will be loaded from a CDN before the rendering occurs.
+     */
+    constructor(mathjax: any = undefined) {
+        this.mathjax = mathjax;
+    }
+
+    /**
+     * Loads MathJax from a CDN.
+     *
+     * @protected
+     */
+    protected loadFromCdn(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const script = document.createElement("script");
+            script.type = "text/javascript";
+            script.src = this.cdnUrl;
+            script.async = true;
+
+            script.onload = () => {
+                // @ts-expect-error After loading the script, window.MathJax will exist.
+                this.mathjax = window.MathJax;
+                resolve();
+            };
+            script.onerror = () => reject(new Error(`Failed to load ${this.cdnUrl}.`));
+
+            document.head.appendChild(script);
+        });
+    }
+
+    /**
+     * Renders LaTeX inside an element.
+     *
+     * @protected
+     */
+    protected abstract _render(element: Element, inline: boolean): Promise<void>;
+
+    /**
+     * Renders LaTeX inside an element. Loads MathJax from a CDN if necessary.
+     */
+    render(element: Element, inline: boolean): Promise<void> {
+        // We do this to chain every render call. This also ensures that we only load once from the CDN:
+        // https://docs.mathjax.org/en/v3.2-latest/web/typeset.html#handling-asynchronous-typesetting
+        return (this.renderQueue = this.renderQueue.then(() => {
+            if (this.mathjax === undefined) {
+                return this.loadFromCdn().then(() => this._render(element, inline));
+            }
+            return this._render(element, inline);
+        }));
+    }
+}

--- a/ts/mathjax/index.ts
+++ b/ts/mathjax/index.ts
@@ -1,0 +1,32 @@
+/* eslint-disable */
+
+import { BaseMathJaxHelper } from "./base";
+import { MathJax2Helper } from "./v2";
+import { MathJax3Helper } from "./v3";
+
+let mathJaxHelper: BaseMathJaxHelper | null = null;
+
+/**
+ * Uses MathJax to render LaTeX inside the given element.
+ *
+ * If MathJax is not available it will be loaded from a CDN.
+ */
+export function renderLaTeX(element: Element, inline: boolean = true): Promise<void> {
+    if (mathJaxHelper === null) {
+        // @ts-expect-error We need to check for the existence of MathJax.
+        const mathjax: any = window.MathJax;
+        if (typeof mathjax === "object") {
+            if (mathjax.version.startsWith("2.")) {
+                mathJaxHelper = new MathJax2Helper(mathjax);
+            } else if (mathjax.version.startsWith("3.")) {
+                mathJaxHelper = new MathJax3Helper(mathjax);
+            } else {
+                return Promise.reject(new Error("Only MathJax 2.x and 3.x are supported."));
+            }
+        } else {
+            mathJaxHelper = new MathJax3Helper();
+        }
+    }
+
+    return mathJaxHelper.render(element, inline);
+}

--- a/ts/mathjax/v2.ts
+++ b/ts/mathjax/v2.ts
@@ -7,7 +7,7 @@ import { BaseMathJaxHelper } from "./base";
  * Docs: https://docs.mathjax.org/en/v2.7-latest/
  */
 export class MathJax2Helper extends BaseMathJaxHelper {
-    protected cdnUrl = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_CHTML";
+    protected cdnUrl = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js";
 
     protected loadFromCdn() {
         // Configure MathJax.
@@ -15,6 +15,8 @@ export class MathJax2Helper extends BaseMathJaxHelper {
         script.type = "text/x-mathjax-config";
         script.text = `
             MathJax.Hub.Config({
+                jax: ["input/TeX","output/CommonHTML"],
+                extensions: ["tex2jax.js", "Safe.js"],
                 tex2jax: {
                     inlineMath: [["\\\\(", "\\\\)"]],
                     displayMath: [["\\\\[", "\\\\]"]],

--- a/ts/mathjax/v2.ts
+++ b/ts/mathjax/v2.ts
@@ -1,0 +1,58 @@
+/* eslint-disable */
+import { BaseMathJaxHelper } from "./base";
+
+/**
+ * Uses MathJax 2 to render LaTeX.
+ *
+ * Docs: https://docs.mathjax.org/en/v2.7-latest/
+ */
+export class MathJax2Helper extends BaseMathJaxHelper {
+    protected cdnUrl = "https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_CHTML";
+
+    protected loadFromCdn() {
+        // Configure MathJax.
+        const script = document.createElement("script");
+        script.type = "text/x-mathjax-config";
+        script.text = `
+            MathJax.Hub.Config({
+                tex2jax: {
+                    inlineMath: [["\\\\(", "\\\\)"]],
+                    displayMath: [["\\\\[", "\\\\]"]],
+                    processEscapes: true,
+                },
+                skipStartupTypeset: true,
+                errorSettings: {message: ["!"]},
+                messageStyle: "none",
+            });
+        `;
+        document.head.appendChild(script);
+        return super.loadFromCdn();
+    }
+
+    protected _render(element: Element, inline: boolean): Promise<void> {
+        return new Promise((resolve, reject) => {
+            try {
+                // Ensure that MathJax is fully initialized.
+                this.mathjax.Hub.Register.StartupHook("End", () => {
+                    // We require the 'tex2jax' extension.
+                    if (this.mathjax.Extension.tex2jax === undefined) {
+                        throw new Error("The 'tex2jax' extension is required.");
+                    }
+
+                    // Get the delimiters.
+                    const inlineDelimiters = this.mathjax.Extension.tex2jax.config.inlineMath[0];
+                    const displayDelimiters = this.mathjax.Extension.tex2jax.config.displayMath[0];
+                    const [openingDelimiter, closingDelimiter] = inline ? inlineDelimiters : displayDelimiters;
+
+                    // Add the delimiters.
+                    element.textContent = `${openingDelimiter} ${element.textContent} ${closingDelimiter}`;
+
+                    // Perform the rendering.
+                    this.mathjax.Hub.Queue(["Typeset", this.mathjax.Hub, element], [resolve]);
+                });
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+}

--- a/ts/mathjax/v3.ts
+++ b/ts/mathjax/v3.ts
@@ -1,0 +1,55 @@
+/* eslint-disable */
+import { BaseMathJaxHelper } from "./base";
+
+/**
+ * Uses MathJax 3 to render LaTeX.
+ *
+ * Docs: https://docs.mathjax.org/en/v3.2-latest/
+ */
+export class MathJax3Helper extends BaseMathJaxHelper {
+    protected cdnUrl = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js";
+
+    protected loadFromCdn() {
+        // Configure MathJax.
+        // @ts-ignore
+        window.MathJax = {
+            tex: {
+                inlineMath: [["\\\\(", "\\\\)"]],
+                displayMath: [["\\\\[", "\\\\]"]],
+                processEscapes: true,
+                autoload: {
+                    color: [],
+                    colorv2: ["color"],
+                },
+                packages: { "[+]": ["noerrors"] },
+            },
+            startup: {
+                typeset: false,
+            },
+            options: {
+                ignoreHtmlClass: "tex2jax_ignore",
+                processHtmlClass: "tex2jax_process",
+            },
+            loader: {
+                load: ["[tex]/noerrors"],
+            },
+        };
+        return super.loadFromCdn();
+    }
+
+    protected _render(element: Element, inline: boolean): Promise<void> {
+        // Ensure that MathJax is fully initialized.
+        return this.mathjax.startup.promise.then(() => {
+            // Get the delimiters.
+            const inlineDelimiters = this.mathjax.config.tex?.inlineMath?.[0] ?? ["\\(", "\\)"];
+            const displayDelimiters = this.mathjax.config.tex?.displayMath?.[0] ?? ["\\[", "\\]"];
+            const [openingDelimiter, closingDelimiter] = inline ? inlineDelimiters : displayDelimiters;
+
+            // Add the delimiters.
+            element.textContent = `${openingDelimiter} ${element.textContent} ${closingDelimiter}`;
+
+            // Perform the rendering.
+            return this.mathjax.typesetPromise([element]);
+        });
+    }
+}

--- a/ts/mathjax/v3.ts
+++ b/ts/mathjax/v3.ts
@@ -17,10 +17,6 @@ export class MathJax3Helper extends BaseMathJaxHelper {
                 inlineMath: [["\\\\(", "\\\\)"]],
                 displayMath: [["\\\\[", "\\\\]"]],
                 processEscapes: true,
-                autoload: {
-                    color: [],
-                    colorv2: ["color"],
-                },
                 packages: { "[+]": ["noerrors"] },
             },
             startup: {
@@ -31,7 +27,7 @@ export class MathJax3Helper extends BaseMathJaxHelper {
                 processHtmlClass: "tex2jax_process",
             },
             loader: {
-                load: ["[tex]/noerrors"],
+                load: ["[tex]/noerrors", "ui/safe"],
             },
         };
         return super.loadFromCdn();

--- a/ts/utils.ts
+++ b/ts/utils.ts
@@ -1,30 +1,6 @@
 import { type OutputFormat, parseBoraToLaTeX } from "./parser/parser.js";
 import { renderLaTeX } from "./mathjax";
 
-/* eslint-disable */
-/**
- * Use MathJax to render the LaTeX inside a specific element.
- *
- * This function supports MathJax 2.x and 3.x.
- */
-export function render(element: Element) {
-    // @ts-ignore
-    const mathjax: any = globalThis.MathJax;
-
-    if (typeof mathjax === "object") {
-        if (mathjax.version.startsWith("2.")) {
-            mathjax.Hub.Queue(["Typeset", mathjax.Hub, element]);
-        } else if (mathjax.version.startsWith("3.")) {
-            // TODO: we might need to chain this: https://docs.mathjax.org/en/latest/web/typeset.html#typeset-async
-            mathjax.typesetPromise([element]);
-        } else {
-            console.warn("Only MathJax 2.x and 3.x are supported, skipping rendering.");
-        }
-    } else {
-        console.warn("MathJax not available, skipping rendering.");
-    }
-}
-/* eslint-enable */
 
 /** Render the Bora-formula to the given element. */
 export function renderBora(formula: string, element: Element, format: OutputFormat) {

--- a/ts/utils.ts
+++ b/ts/utils.ts
@@ -1,4 +1,5 @@
 import { type OutputFormat, parseBoraToLaTeX } from "./parser/parser.js";
+import { renderLaTeX } from "./mathjax";
 
 /* eslint-disable */
 /**
@@ -27,9 +28,8 @@ export function render(element: Element) {
 
 /** Render the Bora-formula to the given element. */
 export function renderBora(formula: string, element: Element, format: OutputFormat) {
-    const latex = parseBoraToLaTeX(formula, format);
-    element.textContent = `\\( ${latex} \\)`;
-    render(element);
+    element.textContent = parseBoraToLaTeX(formula, format);
+    renderLaTeX(element).catch(console.error);
 }
 
 /** Hides one element and shows the other. */


### PR DESCRIPTION
Um leichter weitere (zukünftige) MathJax-Versionen zu unterstützen, habe ich mich dazu entschieden eine `BaseMathJaxHelper` zu erstellen, von welchem die `Helper`-Klassen erben. Diese Klasse hat ausschließlich eine public-Methode: `render`.

`render` stellt sicher, dass `MathJax` verfügbar ist und lädt es ggf. von einem CDN (s. `cdnUrl`). Wenn wir später diese Funktionalität als QuestionPy-Lib-Paket anbieten, sollten wir diese URL, ähnlich wie bei Moodle, einstellbar machen.

`renderLaTeX` (wir können sie auch `renderFormulaMathJax` nennen, fand' ich jetzt aber so cleaner), schaut zunächst, ob bereits MathJax verfügbar ist und verwendet dann für's Rendering den `MathJaxXHelper` der jeweils verfügbaren Version `X`. Falls es nicht verfügbar ist, wird der `MathJax3Helper` verwendet.

Beim Aufruf der jeweiligen `_render`-Methode wird sichergestellt, dass MathJax vollständig geladen ist.